### PR TITLE
Update rust toolchain, and fix yet another stack overflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: nightly-2024-04-30
+        toolchain: nightly-2025-03-15
         components: rustfmt, clippy, rust-src
     - run: cargo clippy
 
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: nightly-2024-04-30
+        toolchain: nightly-2025-03-15
         components: rustfmt, clippy, rust-src
     - run: sudo apt-get install libsdl2-dev
     - run: cargo test
@@ -41,7 +41,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@v1
       with:
         targets: thumbv7em-none-eabihf
-        toolchain: nightly-2024-04-30
+        toolchain: nightly-2025-03-15
         components: rustfmt, clippy, rust-src
     - run: sudo apt-get install libsdl2-dev
     - run: |
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: nightly-2024-04-30
+        toolchain: nightly-2025-03-15
         components: rustfmt, clippy, rust-src
     - run: cargo fmt --check
 
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@v1
       with:
-        toolchain: nightly-2024-04-30
+        toolchain: nightly-2025-03-15
         components: rustfmt, clippy, rust-src
     - run: cargo doc
 

--- a/ppu/src/lib.rs
+++ b/ppu/src/lib.rs
@@ -139,8 +139,8 @@ impl Ppu {
     /// Constructs a PPU instance
     pub fn new() -> Self {
         type UninitFrame = [[core::mem::MaybeUninit<Color>; DISPLAY_WIDTH]; DISPLAY_HEIGHT];
-        let mut framebuffer: UninitFrame =
-            [[core::mem::MaybeUninit::uninit(); DISPLAY_WIDTH]; DISPLAY_HEIGHT];
+        let mut framebuffer: Box<UninitFrame> =
+            Box::new([[core::mem::MaybeUninit::uninit(); DISPLAY_WIDTH]; DISPLAY_HEIGHT]);
 
         for row in framebuffer.iter_mut() {
             for elem in row {
@@ -159,9 +159,9 @@ impl Ppu {
 
             stat_irq: false,
             selected_oam_entries: heapless::Vec::new(),
-            framebuffer: Box::new(unsafe {
-                core::mem::transmute::<UninitFrame, Frame>(framebuffer)
-            }),
+            framebuffer: unsafe {
+                core::mem::transmute::<Box<UninitFrame>, Box<Frame>>(framebuffer)
+            },
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = [ "rustfmt", "rust-analyzer" ]

--- a/rusty-date/rust-toolchain.toml
+++ b/rusty-date/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-04-30"
+channel = "nightly-2025-03-15"
 components = [ "rustfmt", "rust-analyzer", "rust-src" ]
 targets = [ "thumbv7em-none-eabihf" ]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,7 +25,7 @@ enum Commands {
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-const NIGHTLY_TOOLCHAIN: &str = "nightly-2024-04-30";
+const NIGHTLY_TOOLCHAIN: &str = "nightly-2025-03-15";
 
 fn project_root() -> PathBuf {
     Path::new(&env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
Because, of course, the new toolchain did not optimize the stack usage like the previous versions and now constructed the Frame in the stack, then moved it to the heap.